### PR TITLE
Simplified validation of payload

### DIFF
--- a/src/main/kotlin/no/skatteetaten/aurora/herkimer/controller/ApplicationDeploymentController.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/herkimer/controller/ApplicationDeploymentController.kt
@@ -1,12 +1,6 @@
 package no.skatteetaten.aurora.herkimer.controller
 
-import javax.validation.Constraint
-import javax.validation.ConstraintValidator
-import javax.validation.ConstraintValidatorContext
-import javax.validation.Payload
 import javax.validation.Valid
-import kotlin.reflect.KClass
-import kotlin.reflect.full.declaredMemberProperties
 import org.springframework.util.StringUtils
 import no.skatteetaten.aurora.herkimer.dao.PrincipalUID
 import no.skatteetaten.aurora.herkimer.service.PrincipalService
@@ -28,13 +22,19 @@ data class ApplicationDeploymentPayload(
     val businessGroup: String
 )
 
-@RequireAtLeastOnePropValue
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class ApplicationMigrationPayload(
     val environmentName: String? = null,
     val cluster: String? = null,
     val businessGroup: String? = null
-)
+) {
+    fun validateAtLeastOneFieldIsSet() {
+        val fieldsThatAreSet = listOfNotNull(environmentName, cluster, businessGroup)
+        if (fieldsThatAreSet.isEmpty()) {
+            throw IllegalArgumentException("Requires at least one field of the payload to be set")
+        }
+    }
+}
 
 @RestController
 @RequestMapping("/applicationDeployment")
@@ -89,6 +89,8 @@ class ApplicationDeploymentController(
         @PathVariable id: PrincipalUID,
         @Valid @RequestBody payload: ApplicationMigrationPayload
     ): AuroraResponse<ApplicationDeployment> {
+        payload.validateAtLeastOneFieldIsSet()
+
         val existingAd = principalService.findApplicationDeployment(id)
             ?: throw NoSuchResourceException("Could not find ApplicationDeployment with id=$id")
         return payload.run {
@@ -111,37 +113,5 @@ class ApplicationDeploymentController(
             return prop!!
         }
         return fallback
-    }
-}
-
-@Target(AnnotationTarget.CLASS)
-@Retention(AnnotationRetention.RUNTIME)
-@Constraint(validatedBy = [RequireAtLeastOnePropValueValidator::class])
-annotation class RequireAtLeastOnePropValue(
-    val message: String = "at least one property must have a valid value",
-    val groups: Array<KClass<*>> = [],
-    val payload: Array<KClass<out Payload>> = []
-)
-
-// validate that object contains at least one declared property that is non-null and not empty string
-class RequireAtLeastOnePropValueValidator : ConstraintValidator<RequireAtLeastOnePropValue, Any> {
-    override fun isValid(p0: Any?, p1: ConstraintValidatorContext?): Boolean {
-        if (p0 == null) {
-            return false
-        }
-        var valid = false
-
-        p0.javaClass.kotlin.declaredMemberProperties.forEach {
-            val v = it.get(p0)
-            if (v != null) {
-                valid = if (v is String) {
-                    v != "" // if string ensure it is not blank
-                } else {
-                    true // if not string assume non-null value is valid
-                }
-            }
-        }
-
-        return valid
     }
 }

--- a/src/test/kotlin/no/skatteetaten/aurora/herkimer/controller/ApplicationDeploymentControllerContractTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/herkimer/controller/ApplicationDeploymentControllerContractTest.kt
@@ -19,9 +19,7 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.HttpHeaders
-import org.springframework.http.HttpStatus
 import org.springframework.test.web.servlet.MockMvc
-import no.skatteetaten.aurora.mockmvc.extensions.status
 
 @AutoConfigureEmbeddedDatabase(provider = ZONKY)
 @SpringBootTest(properties = ["aurora.authentication.token.value=secret_from_file", "aurora.authentication.enabled=false"])
@@ -134,41 +132,6 @@ class ApplicationDeploymentControllerContractTest {
                 .responseJsonPath("$.success").isTrue()
                 .responseJsonPath("$.items[0].id").equalsValue(adId)
                 .responseJsonPath("$.items[0].cluster").equalsValue("utv04")
-        }
-    }
-
-    @Test
-    fun `Migrate ApplicationDeployment When payload contains one valid property Then only the provided property is modified`() {
-        val prefix = Math.random().toString()
-        val adId = testDataCreators.createApplicationDeploymentAndReturnId(prefix = prefix)
-
-        val migratedAd = ApplicationMigrationPayload(environmentName = "test-env", cluster = "")
-
-        mockMvc.patch(
-            path = Path("/applicationDeployment/{adId}", adId),
-            headers = HttpHeaders().contentTypeJson(),
-            body = migratedAd
-        ) {
-            statusIsOk()
-                .responseJsonPath("$.count").equalsValue(1)
-                .responseJsonPath("$.success").isTrue()
-                .responseJsonPath("$.items[0].id").equalsValue(adId)
-                .responseJsonPath("$.items[0].environmentName").equalsValue("test-env")
-                .responseJsonPath("$.items[0].cluster").equalsValue("$prefix-cluster")
-                .responseJsonPath("$.items[0].businessGroup").equalsValue("$prefix-aurora")
-        }
-    }
-
-    @Test
-    fun `Migrate ApplicationDeployment When payload contains null and empty properties Then return HTTP_BAD_REQUEST`() {
-        val adId = testDataCreators.createApplicationDeploymentAndReturnId()
-
-        mockMvc.patch(
-            path = Path("/applicationDeployment/{adId}", adId),
-            headers = HttpHeaders().contentTypeJson(),
-            body = ApplicationMigrationPayload()
-        ) {
-            status(HttpStatus.BAD_REQUEST)
         }
     }
 }


### PR DESCRIPTION
Jeg lagde et forslag for hvordan vi kan gjøre valideringen enklere. Hva tenker du? Var litt enklere å foreslå i kode
Vi mister sjekken om felter er tomme, men jeg er usikker på om det er herkimer sitt ansvar å ha den logikken. Fordi i dag så tillater vi f.eks tom environmentName

Flyttet testene fra contract tester til vanlig. Det funker kun med happy cases når man genererer slike kontrakt stubber